### PR TITLE
Implement page number as search parameter

### DIFF
--- a/src/Carousel/Carousel.js
+++ b/src/Carousel/Carousel.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useSwipeable } from "react-swipeable";
 import Pagination from "@mui/material/Pagination";
+import { useSearchParams } from "react-router-dom";
 
 import "./Carousel.css";
 
@@ -13,26 +14,34 @@ export const CarouselItem = ({ children, width }) => {
 };
 
 const Carousel = ({ children }) => {
-  const [activeIndex, setActiveIndex] = useState(0);
+  // console.log("carousel rendered");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const pageParam = searchParams.has("page") ? parseInt(searchParams.get("page")) : 0; // default to 0 if no search parameter present
+  const [activeIndex, setActiveIndex] = useState(pageParam);
+  const childrenCount = React.Children.count(children);
   useEffect(() => {
+    // console.log("effect used"); 
+
     // Subscribe once
-    window.addEventListener("keydown", keyPress);
+    document.addEventListener("keydown", keyPress);
     // Unsubscribe on unmount
     return () => {
-      window.removeEventListener("keydown", keyPress);
+      document.removeEventListener("keydown", keyPress);
     };
-  });
+  }, [activeIndex, childrenCount]);
 
   // Update index of image to display
   const updateIndex = (e, p) => {
     p = p - 1;
-    if (p < 0) {
+    if (p < 0) { // wraparound to last element
       p = React.Children.count(children) - 1;
-    } else if (p >= React.Children.count(children)) {
+    } else if (p >= React.Children.count(children)) { // wraparound to first element
       p = 0;
     }
 
     setActiveIndex(p);
+
+    setSearchParams({page: p+1});
   };
 
   // Mobile swiping support
@@ -70,7 +79,7 @@ const Carousel = ({ children }) => {
           count={React.Children.count(children)}
           showFirstButton
           showLastButton
-          page={activeIndex+1}
+          page={activeIndex + 1}
           onChange={updateIndex}
           variant="outlined"
         />

--- a/src/Carousel/CarouselWrapper.js
+++ b/src/Carousel/CarouselWrapper.js
@@ -10,11 +10,13 @@ const CarouselWrapper = () => {
   const [listItems, setListItems] = useState();
   const { id } = useParams();
   const category = gridData[id].tag;
+  let dataFetched = false;
 
   async function getData() {
     setData(await import("./Data/" + category));
-
-    if (data)
+    
+    if (data) {
+      dataFetched = true; // carousel data only needs to be fetched once
       setListItems(
         data.carouselData.map((element, index) => {
           return (
@@ -27,17 +29,20 @@ const CarouselWrapper = () => {
                 ></img>
               </div>
               <div className="carousel-item-author">
-                Author: {element.author} {element.link ? <a href={element.link}>(link)</a> : null}
+                Author: {element.author}{" "}
+                {element.link ? <a href={element.link}>(link)</a> : null}
               </div>
             </CarouselItem>
           );
         })
       );
+    }
   }
 
   useEffect(() => {
-    getData();
-  });
+    // console.log("CarouselWrapper effect used");
+    if (!dataFetched) getData();
+  }, [data]);
   return <Carousel>{listItems}</Carousel>;
 };
 


### PR DESCRIPTION
The ?page=# query parameter is now automatically set in the Carousel, such that it corresponds to a specific image on the carousel. This will allow for bookmarking the page and coming back to a specific image, or accessing a specific image by editing the url query parameter.
Page freezing due to infinite re-rendering has also been fixed by carefully using the optional dependencies parameter for useEffect().