### PR TITLE
Implement description box for grid categories

### DIFF
--- a/src/GridView/GridView.css
+++ b/src/GridView/GridView.css
@@ -9,23 +9,28 @@
 
 .grid-item {
   position: relative;
-  cursor: pointer;
 }
 
 .grid-item-image {
+  cursor: pointer;
   max-width: 100%;
   max-height: 40vh;
   -webkit-filter: blur(1px);
 }
 
 .grid-item-tag {
+  cursor: help;
   position: absolute;
   margin: auto;
   inset: 0;
-  height: 100px;
+  height: fit-content;
   width: 100%;
   color: white;
   -webkit-text-stroke-width: 0.5px;
   -webkit-text-stroke-color: black;
   text-shadow: #474747 1px 1px 1px;
+}
+
+.grid-alert {
+  color: white;
 }

--- a/src/GridView/GridView.js
+++ b/src/GridView/GridView.js
@@ -4,18 +4,32 @@ import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import { gridData } from "../gridData";
 import { Navigate } from "react-router-dom";
+import Alert from "@mui/material/Alert";
+import AlertTitle from "@mui/material/AlertTitle";
+import { createTheme, ThemeProvider } from "@mui/material/styles";
+
+const theme = createTheme({
+  palette: {
+    info: {
+      main: "#4d432f",
+    },
+  },
+});
 
 function GridItem(props) {
   return (
     <Grid className="grid-container" item xs="auto">
-      <div className="grid-item" onClick={props.onClick}>
+      <div className={"grid-item grid-item-" + props.tag.replace(/\s+/g, "")}>
         <img
           alt="thumb"
           className="grid-item-image"
           title={props.desc}
           src={props.image}
+          onClick={props.onClick}
         ></img>
-        <div className="grid-item-tag">{props.tag}</div>
+        <div className="grid-item-tag" onClick={props.onTagClick}>
+          {props.tag}
+        </div>
       </div>
     </Grid>
   );
@@ -27,12 +41,45 @@ class GridView extends React.Component {
     this.state = {
       gridData: gridData,
       navigateTo: null,
+      categoryInfoMessage: null,
     };
   }
 
   // Navigate to carousel view for whichever category was clicked
   handleClick(i) {
     this.setState({ navigateTo: i });
+  }
+
+  // Show description message box for a category
+  showCategoryInfo(tag, desc) {
+    this.setState((prevState) => {
+      return {
+        ...prevState,
+        categoryInfoMessage: (
+          <Box display="flex" justifyContent="center" alignItems="center">
+            <ThemeProvider theme={theme}>
+              <Alert
+                severity="info"
+                variant="filled"
+                sx={{ color: "white", width: "fit-content" }}
+                onClose={() => {
+                  this.setState((prevState) => {
+                    return { ...prevState, categoryInfoMessage: null };
+                  });
+                }}
+              >
+                <AlertTitle>
+                  <strong>Category: </strong>
+                  {tag}
+                </AlertTitle>
+                <strong>Description: </strong>
+                {desc}
+              </Alert>
+            </ThemeProvider>
+          </Box>
+        ),
+      };
+    });
   }
 
   // Render a single GridItem
@@ -43,6 +90,12 @@ class GridView extends React.Component {
         image={this.state.gridData[category].image}
         desc={this.state.gridData[category].desc}
         onClick={() => this.handleClick(category)}
+        onTagClick={() =>
+          this.showCategoryInfo(
+            this.state.gridData[category].tag,
+            this.state.gridData[category].desc
+          )
+        }
       />
     );
   }
@@ -57,6 +110,8 @@ class GridView extends React.Component {
 
     return (
       <Box sx={{ flexGrow: 1, marginTop: "10px" }}>
+        {this.state.categoryInfoMessage}
+
         <Grid container spacing={2} sx={{ p: 1 }}>
           {gridItemsArray.map((component, index) => (
             <React.Fragment key={index}>{component}</React.Fragment>

--- a/src/Navbar/DefaultNavbar.tsx
+++ b/src/Navbar/DefaultNavbar.tsx
@@ -37,7 +37,7 @@ function DefaultNavbar() {
                 display: { xs: 'none', md: 'flex' },
                 fontFamily: 'sans-serif',
                 fontWeight: 700,
-                color: '#fdf8ed',
+                color: '#fff',
                 textDecoration: 'none',
               }}
             >
@@ -48,7 +48,7 @@ function DefaultNavbar() {
               {pages.map((page) => (
                 <Button
                   key={page}
-                  sx={{ my: 2, color: '#fdf8ed', display: 'block' }}
+                  sx={{ my: 2, color: '#fff', display: 'block' }}
                   component={Link}
                   to={page}
                 >

--- a/src/gridData.js
+++ b/src/gridData.js
@@ -21,84 +21,84 @@ export const gridData={
     {
       "tag": "Valve-Style Portraits",
       "image": Thumb_Valve_Portraits,
-      "desc": "Character portraits made in Valve's iconic style."
+      "desc": "Character portraits made in Valve's iconic style"
     },
     "POV_Punch":
     {
       "tag": "POV Punch",
       "image": Thumb_POV_Punch,
-      "desc": "POV of a character punching the viewer with exaggerated perspective."
+      "desc": "POV shots of a character punching the viewer with exaggerated perspective"
     },
     "Extreme_Long_Shots":
     {
       "tag": "Extreme Long Shots",
       "image": Thumb_Extreme_Long_Shots,
-      "desc": "Shots that frame the character from a distance, focusing more on their surroundings."
+      "desc": "Shots that frame the character from a distance, focusing more on their surroundings"
     },
     "Full_Shots":
     {
       "tag": "Full Shots",
       "image": Thumb_Full_Shots,
-      "desc": "Shots that focus on a single character's full body, head to toe."
+      "desc": "Shots that focus on a single character's full body, head to toe"
     },
     "Medium_Shots":
     {
       "tag": "Medium Shots",
       "image": Thumb_Medium_Shots,
-      "desc": "Shots of a single character from around the waist up."
+      "desc": "Shots of a single character from around the waist up"
     },
     "Medium_Close-Up_Shots":
     {
       "tag": "Medium Close-Up Shots",
       "image": Thumb_Medium_Close_Up_Shots,
-      "desc": "Shots of a single character from around the chest or shoulders up."
+      "desc": "Shots of a single character from around the chest or shoulders up"
     },
     "Close-Up_Shots":
     {
       "tag": "Close-Up Shots",
       "image": Thumb_Close_Up_Shots,
-      "desc": "Shots of a single character's face."
+      "desc": "Shots of a single character's face"
     },
     "Movie_and_Game_Posters":
     {
       "tag": "Movie and Game Posters",
       "image": Thumb_Movie_and_Game_Posters,
-      "desc": "Parodies of movie, game, and other media's poster art."
+      "desc": "Parodies of promotional posters from movies, games, and other forms of media"
     },
     "Scenebuilds":
     {
       "tag": "Scenebuilds",
       "image": Thumb_Scenebuilds,
-      "desc": "Scenebuilds that don't focus on characters."
+      "desc": "Scenebuilds that don't focus on characters"
     },
     "JoJo_Approach":
     {
       "tag": "JoJo Approach",
       "image": Thumb_JoJo_Approach,
-      "desc": "Composition mimicking the 'Oh? You're Approaching Me?' scene from JoJo's Bizarre Adventure."
+      "desc": "Composition mimicking the 'Oh? You're Approaching Me?' scene from JoJo's Bizarre Adventure"
     },
     "Black_Bars":
     {
       "tag": "Black Bars",
       "image": Thumb_Black_Bars,
-      "desc": "Creative uses of (diagonal) posable black bars."
+      "desc": "Creative uses of (diagonal) posable black bars"
     },
     "Cars":
     {
       "tag": "Cars",
       "image": Thumb_Cars,
-      "desc": "Shots prominently featuring cars."
+      "desc": "Shots that focus on cars"
     },
     "Planes":
     {
       "tag": "Planes",
       "image": Thumb_Planes,
-      "desc": "Shots prominently featuring planes or other aircraft."
+      "desc": "Shots that focus on planes or other aircraft"
     },
     "Deformed_Mercs":
     {
       "tag": "Deformed Mercs",
       "image": Thumb_Deformed_Mercs,
-      "desc": "TF2 mercenaries deformed into strange monstrosities."
+      "desc": "TF2 mercenaries deformed into strange monstrosities"
     },
 };


### PR DESCRIPTION
When the user clicks on a tag on the grid view, show an alert message which provides the category name and description at the top of the page. This message won't scroll with the page, and it can be closed. Description tooltips on hover remain unchanged.